### PR TITLE
fix: recommender accuracy — match semantically equivalent service names

### DIFF
--- a/src/app/(discovery)/recommender/actions.ts
+++ b/src/app/(discovery)/recommender/actions.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/db";
 import { providers, providerCategories, categories, services } from "@/db/schema";
-import { eq, and, ilike, exists } from "drizzle-orm";
+import { eq, and, ilike, exists, inArray } from "drizzle-orm";
 
 /**
  * Fetches all active providers matching the given category and suburb.
@@ -12,7 +12,7 @@ import { eq, and, ilike, exists } from "drizzle-orm";
 export async function getRecommendedProviders(
   categoryName: string,
   suburbParam: string,
-  serviceFilter: string | null = null
+  serviceFilter: string[] | null = null  // array of service names to match (any), or null for no filter
 ) {
   const conditions = [eq(providers.status, "active")];
 
@@ -36,8 +36,10 @@ export async function getRecommendedProviders(
     )
   );
 
-  // If a specific service was selected, further narrow to providers offering that service
-  if (serviceFilter) {
+  // If specific services were selected, narrow to providers offering ANY of those service names.
+  // Using an array + inArray allows multiple semantically equivalent service names to match
+  // (e.g. "Screen Replacement" and "On-Site Screen Repair" are both valid for a cracked screen).
+  if (serviceFilter && serviceFilter.length > 0) {
     conditions.push(
       exists(
         db
@@ -47,7 +49,7 @@ export async function getRecommendedProviders(
             and(
               eq(services.providerId, providers.id),
               eq(services.isActive, true),
-              eq(services.name, serviceFilter) // exact match — value comes from our controlled mapping
+              inArray(services.name, serviceFilter) // matches any of the provided service names
             )
           )
       )
@@ -68,9 +70,10 @@ export async function getRecommendedProviders(
         .innerJoin(categories, eq(providerCategories.categoryId, categories.id))
         .where(eq(providerCategories.providerId, p.id));
 
-      // When a specific service is filtered, prefer that service's price for accuracy
+      // When specific services are filtered, prefer the matched service's price.
+      // Use the first service from serviceFilter that this provider actually has.
       let specificServiceRows: { startingPrice: string | null }[] = [];
-      if (serviceFilter) {
+      if (serviceFilter && serviceFilter.length > 0) {
         specificServiceRows = await db
           .select({ startingPrice: services.startingPrice })
           .from(services)
@@ -78,7 +81,7 @@ export async function getRecommendedProviders(
             and(
               eq(services.providerId, p.id),
               eq(services.isActive, true),
-              eq(services.name, serviceFilter)
+              inArray(services.name, serviceFilter)
             )
           )
           .limit(1);

--- a/src/app/(discovery)/recommender/page.tsx
+++ b/src/app/(discovery)/recommender/page.tsx
@@ -19,15 +19,15 @@ type ItemType = "phone" | "laptop" | "appliance" | "clothing" | "bicycle";
 type ProblemOption = {
   value: string;
   label: string;
-  /** Exact service name in the DB to filter by. null = show all providers in the category. */
-  serviceFilter: string | null;
+  /** Service name(s) in the DB to filter by. null = show all providers in the category. */
+  serviceFilter: string[] | null;
 };
 
 type RecommenderAnswers = {
   item: ItemType | "";
   problem: string;
-  /** Resolved service name to pass to the server action. null = no service filter. */
-  serviceFilter: string | null;
+  /** Resolved service names to pass to the server action. null = no service filter. */
+  serviceFilter: string[] | null;
   suburb: string;
 };
 
@@ -48,38 +48,40 @@ const ITEM_OPTIONS: { value: ItemType; label: string }[] = [
  */
 const ITEM_PROBLEM_OPTIONS: Record<ItemType, ProblemOption[]> = {
   phone: [
-    { value: "screen", label: "Screen is cracked or broken", serviceFilter: "Screen Replacement" },
-    { value: "battery", label: "Battery or charging issue", serviceFilter: "Battery Replacement" },
-    { value: "charging-port", label: "Charging port not working", serviceFilter: "Charging Port Fix" },
-    { value: "water", label: "Water damage", serviceFilter: "Water Damage Repair" },
-    { value: "data", label: "Need data recovered", serviceFilter: "Data Recovery" },
+    // Both "Screen Replacement" (FixIt Phone Lab) and "On-Site Screen Repair" (Mobile Medics)
+    // represent the same user problem — include both so neither provider is excluded.
+    { value: "screen", label: "Screen is cracked or broken", serviceFilter: ["Screen Replacement", "On-Site Screen Repair"] },
+    { value: "battery", label: "Battery or charging issue", serviceFilter: ["Battery Replacement"] },
+    { value: "charging-port", label: "Charging port not working", serviceFilter: ["Charging Port Fix"] },
+    { value: "water", label: "Water damage", serviceFilter: ["Water Damage Repair"] },
+    { value: "data", label: "Need data recovered", serviceFilter: ["Data Recovery"] },
     { value: "other", label: "Other / Not sure", serviceFilter: null },
   ],
   laptop: [
-    { value: "screen", label: "Screen is cracked or broken", serviceFilter: "Laptop Screen Replacement" },
-    { value: "slow", label: "Running slow / needs upgrade", serviceFilter: "RAM/SSD Upgrade" },
-    { value: "diagnostic", label: "Won't turn on / needs full diagnostic", serviceFilter: "Full Diagnostic" },
-    { value: "data", label: "Need data recovered", serviceFilter: "Data Recovery" },
+    { value: "screen", label: "Screen is cracked or broken", serviceFilter: ["Laptop Screen Replacement"] },
+    { value: "slow", label: "Running slow / needs upgrade", serviceFilter: ["RAM/SSD Upgrade"] },
+    { value: "diagnostic", label: "Won't turn on / needs full diagnostic", serviceFilter: ["Full Diagnostic"] },
+    { value: "data", label: "Need data recovered", serviceFilter: ["Data Recovery"] },
     { value: "other", label: "Other / Not sure", serviceFilter: null },
   ],
   appliance: [
-    { value: "fridge", label: "Fridge issue", serviceFilter: "Fridge Repair" },
-    { value: "oven", label: "Oven or stove issue", serviceFilter: "Oven/Stove Repair" },
-    { value: "washing", label: "Washing machine issue", serviceFilter: "Washing Machine Repair" },
+    { value: "fridge", label: "Fridge issue", serviceFilter: ["Fridge Repair"] },
+    { value: "oven", label: "Oven or stove issue", serviceFilter: ["Oven/Stove Repair"] },
+    { value: "washing", label: "Washing machine issue", serviceFilter: ["Washing Machine Repair"] },
     { value: "other", label: "Other appliance", serviceFilter: null },
   ],
   clothing: [
-    { value: "hemming", label: "Hemming or shortening", serviceFilter: "Hemming" },
-    { value: "zip", label: "Broken zip", serviceFilter: "Zip Replacement" },
-    { value: "fitting", label: "Custom fitting or tailoring", serviceFilter: "Custom Fitting" },
+    { value: "hemming", label: "Hemming or shortening", serviceFilter: ["Hemming"] },
+    { value: "zip", label: "Broken zip", serviceFilter: ["Zip Replacement"] },
+    { value: "fitting", label: "Custom fitting or tailoring", serviceFilter: ["Custom Fitting"] },
     { value: "other", label: "Other alteration", serviceFilter: null },
   ],
   bicycle: [
-    { value: "tune", label: "Needs a tune-up", serviceFilter: "Basic Tune-Up" },
-    { value: "brakes", label: "Brake issue", serviceFilter: "Brake Adjustment" },
-    { value: "full-service", label: "Full service", serviceFilter: "Full Service" },
-    { value: "tyre", label: "Flat tyre or tyre replacement", serviceFilter: "Tyre Replacement" },
-    { value: "wheel", label: "Wheel or rim issue", serviceFilter: "Wheel Truing" },
+    { value: "tune", label: "Needs a tune-up", serviceFilter: ["Basic Tune-Up"] },
+    { value: "brakes", label: "Brake issue", serviceFilter: ["Brake Adjustment"] },
+    { value: "full-service", label: "Full service", serviceFilter: ["Full Service"] },
+    { value: "tyre", label: "Flat tyre or tyre replacement", serviceFilter: ["Tyre Replacement"] },
+    { value: "wheel", label: "Wheel or rim issue", serviceFilter: ["Wheel Truing"] },
     { value: "other", label: "Other / Not sure", serviceFilter: null },
   ],
 };
@@ -245,7 +247,7 @@ export default function RecommenderPage() {
                 label="What's the issue?"
                 value={answers.problem}
                 onChange={(event) => {
-                  // Resolve the serviceFilter from the selected problem option
+                  // Resolve the serviceFilter array from the selected problem option
                   const selectedOption = ITEM_PROBLEM_OPTIONS[answers.item as ItemType].find(
                     (opt) => opt.value === event.target.value
                   );
@@ -326,8 +328,8 @@ export default function RecommenderPage() {
               <div className="mb-6">
                 <h3 className="text-2xl font-bold text-slate-900 dark:text-white">{recommendation}</h3>
 
-                {/* Show the specific issue label when a service filter was active */}
-                {problemLabel && answers.serviceFilter && (
+                {/* Show the specific issue label when a service filter is active */}
+                {problemLabel && answers.serviceFilter && answers.serviceFilter.length > 0 && (
                   <p className="mt-1 text-sm font-semibold text-teal-600 dark:text-teal-400">
                     Filtered for: {problemLabel}
                   </p>


### PR DESCRIPTION
## Problem

The service filter used `eq(services.name, serviceFilter)` — an exact SQL `=` match on a single string. This caused providers to be silently excluded when two different providers used different (but semantically equivalent) service names for the same type of repair.

**Concrete example:**
- User selects **Phone → Screen is cracked**
- `serviceFilter` was `"Screen Replacement"` (exact match)
- **FixIt Phone Lab** → has `Screen Replacement` ✓ — appeared in results
- **Mobile Medics Brisbane** → has `On-Site Screen Repair` ✗ — was excluded, despite offering exactly what the user needs

## Root Cause

Service names are not standardised across providers. Different businesses name the same service differently. A single exact string match cannot cover this variation.

## Fix

- Changed `serviceFilter` type from `string | null` to `string[] | null` across `page.tsx` and `actions.ts`
- Replaced `eq(services.name, serviceFilter)` with `inArray(services.name, serviceFilter)` — SQL `IN(...)` operator — allowing multiple aliases per problem type
- Updated `ITEM_PROBLEM_OPTIONS` to use `string[]` for all service filters
- The phone **screen** option now maps to `["Screen Replacement", "On-Site Screen Repair"]`, ensuring both FixIt Phone Lab and Mobile Medics Brisbane appear in results

## Branch note

This is a follow-up to the merged PR #35 (`feature/recommender-inline`). The feature branch was deleted after merge so a new `bugfix/` branch was created from updated `main`.

## Files changed
- `src/app/(discovery)/recommender/actions.ts`
- `src/app/(discovery)/recommender/page.tsx`